### PR TITLE
Fix bug where not having a prefix would cause the tap to fail

### DIFF
--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -92,6 +92,10 @@ class SFTPConnection():
         Returns a list of filepaths from the root.
         """
         files = []
+
+        if prefix is None or prefix == '':
+            prefix = '.'
+
         try:
             result = self.sftp.listdir_attr(prefix)
         except FileNotFoundError as e:


### PR DESCRIPTION
# Description of change
 https://stitchdata.atlassian.net/browse/SRCE-1760

Fixed the issue when the prefix was blank or None.

# Automatic QA steps
 - Updated tests to have a table with an empty search_prefix
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
