### PR TITLE
Remove schema_name from metadata generation

### DIFF
--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -13,7 +13,6 @@ def discover_streams(config):
     for table_spec in tables:
         schema = sampling.get_sampled_schema_for_table(conn, table_spec)
         stream_md = metadata.get_standard_metadata(schema,
-                                                   schema_name = table_spec.get('table_name'),
                                                    key_properties=table_spec.get('key_properties'),
                                                    replication_method='INCREMENTAL')
         streams.append(


### PR DESCRIPTION
# Description of change

Noticed that schema_name was being output when it should not be.

# Manual QA steps
 - Verify the Stitch UI behaves correctly.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
