### PR TITLE
Bump to v0.0.6 and increase singer-encodings version to get zip support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-sftp",
-    version="0.0.5",
+    version="0.0.6",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_sftp"],
     install_requires=[
-        "singer-python==5.8.1",
+        "singer-python==5.9.0",
         'paramiko==2.6.0',
         'backoff==1.8.0',
         'singer-encodings==0.0.5',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.8.1",
         'paramiko==2.6.0',
         'backoff==1.8.0',
-        'singer-encodings==0.0.4',
+        'singer-encodings==0.0.5',
         'terminaltables==3.1.0',
     ],
     extras_require={


### PR DESCRIPTION
# Description of change
Bumps the singer-encodings version to get support for zip archives

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
