### PR TITLE
use delimiter option during sync

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.9.0",
         'paramiko==2.6.0',
         'backoff==1.8.0',
-        'singer-encodings==0.0.6',
+        'singer-encodings==0.0.7',
         'terminaltables==3.1.0',
     ],
     extras_require={

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -51,6 +51,7 @@ def sync_file(conn, f, stream, table_spec):
 
     # Add file_name to opts and flag infer_compression to support gzipped files
     opts = {'key_properties': table_spec['key_properties'],
+            'delimiter': table_spec['delimiter'],
             'file_name': f['filepath']}
 
     readers = csv.get_row_iterators(file_handle, options=opts, infer_compression=True)


### PR DESCRIPTION
# Description of change
Add the delimiter to the options during sync

# Manual QA steps
 - Tested syncing with '\t' as a delimiter
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
