### PR TITLE
Default to UTC epoch now if mtime is null

### DIFF
--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -112,10 +112,17 @@ class SFTPConnection():
             else:
                 if is_empty(file_attr):
                     continue
+
+                last_modified = file_attr.st_mtime
+                if last_modified is None:
+                    LOGGER.warning("Cannot read m_time for file %s, defaulting to epoch time 0",
+                                   os.path.join(prefix, file_attr.filename))
+                    last_modified = 0
+
                 # NB: SFTP specifies path characters to be '/'
                 #     https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-6
                 files.append({"filepath": prefix + '/' + file_attr.filename,
-                              "last_modified": datetime.utcfromtimestamp(file_attr.st_mtime).replace(tzinfo=pytz.UTC)})
+                              "last_modified": datetime.utcfromtimestamp(last_modified).replace(tzinfo=pytz.UTC)})
 
         return files
 

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -115,9 +115,9 @@ class SFTPConnection():
 
                 last_modified = file_attr.st_mtime
                 if last_modified is None:
-                    LOGGER.warning("Cannot read m_time for file %s, defaulting to epoch time 0",
+                    LOGGER.warning("Cannot read m_time for file %s, defaulting to current epoch time",
                                    os.path.join(prefix, file_attr.filename))
-                    last_modified = 0
+                    last_modified = datetime.utcnow().timestamp()
 
                 # NB: SFTP specifies path characters to be '/'
                 #     https://tools.ietf.org/html/draft-ietf-secsh-filexfer-13#section-6


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-1287

When running discovery, it appears that in some situations the server will return a file as existing, but the `st_atime` and `st_mtime` will be null. THis PR works around this situation by interpreting these files as having an mtime of the current UTC epoch time.

# Manual QA steps
 - Ran through this against a server that returns `null` and discovery succeeds.
 - Ran through a sync and confirmed that these files were extracted on first and second sync
 
# Risks
 - Medium. This will change the behavior silently of some files that the tap cannot read the m_time for, causing them to always be extracted, which is certainly not ideal.
 
# Rollback steps
 - revert this branch, release new version.
