### PR TITLE
Fall back to username/password when key based fails

### DIFF
--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -52,7 +52,7 @@ class SFTPConnection():
 
     @property
     def sftp(self):
-        self.__try_connection()
+        self.__try_connect()
         return self.__sftp
 
     @sftp.setter

--- a/tap_sftp/client.py
+++ b/tap_sftp/client.py
@@ -36,29 +36,23 @@ class SFTPConnection():
                           jitter=None,
                           factor=2)
     def __try_connect(self):
-        try:
-            self.transport = paramiko.Transport((self.host, self.port))
-            self.transport.use_compression(True)
-            self.transport.connect(username = self.username, password = self.password, hostkey = None, pkey = self.key)
-            self.sftp = paramiko.SFTPClient.from_transport(self.transport)
-        except (AuthenticationException, SSHException) as ex:
-            self.transport.close()
-            self.transport = paramiko.Transport((self.host, self.port))
-            self.transport.use_compression(True)
-            self.transport.connect(username= self.username, password = self.password, hostkey = None, pkey = None)
-            self.sftp = paramiko.SFTPClient.from_transport(self.transport)
-
-    def __ensure_connection(self):
         if not self.__active_connection:
             try:
-                self.__try_connect()
+                self.transport = paramiko.Transport((self.host, self.port))
+                self.transport.use_compression(True)
+                self.transport.connect(username = self.username, password = self.password, hostkey = None, pkey = self.key)
+                self.sftp = paramiko.SFTPClient.from_transport(self.transport)
             except (AuthenticationException, SSHException) as ex:
-                raise Exception("Message from SFTP server: {} - Please ensure that the credentials are valid.".format(ex)) from ex
+                self.transport.close()
+                self.transport = paramiko.Transport((self.host, self.port))
+                self.transport.use_compression(True)
+                self.transport.connect(username= self.username, password = self.password, hostkey = None, pkey = None)
+                self.sftp = paramiko.SFTPClient.from_transport(self.transport)
             self.__active_connection = True
 
     @property
     def sftp(self):
-        self.__ensure_connection()
+        self.__try_connection()
         return self.__sftp
 
     @sftp.setter


### PR DESCRIPTION
# Description of change
The tap was not correctly falling back to password based auth when key based failed. The error is thrown when `paramiko.SFTPClient.from_transport(self.transport)` is called, not when `self.transport.connect(username = self.username, password = self.password, hostkey = None, pkey = self.key)` is called. Moved the `from_transport()` call into the `__try_connect()` body and added the exception type the customer was seeing upon auth.

# Manual QA steps
 - Ran discovery the tap on a cloned connection against the customer's account. 
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
