### PR TITLE
Enhance Tap-sftp to Support Multiple Encoding Formats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-sftp/bin/activate
-            pip install nose coverage
+            pip install nose coverage parameterized
             nosetests --with-coverage --cover-erase --cover-package=tap_sftp --cover-html-dir=htmlcov tests/unittests
             coverage html
       - store_test_results:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+  * Support Multiple Encoding Formats [#36](https://github.com/singer-io/tap-sftp/pull/44)
+
 ## 1.1.2
   * Request Timeout Implementation [#36](https://github.com/singer-io/tap-sftp/pull/36)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-sftp",
-    version="1.1.2",
+    version="1.2.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.12.1",
         'paramiko==2.6.0',
         'backoff==1.8.0',
-        'singer-encodings==0.1.1',
+        'singer-encodings==0.1.3',
         'terminaltables==3.1.0',
     ],
     extras_require={

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -20,7 +20,7 @@ def do_discover(config):
     encoding_format = config.get("encoding_format") or DEFAULT_ENCODING_FORMAT
     if encoding_format != "utf-8":
         if not is_valid_encoding(encoding_format):
-            raise Exception(f"Unknown Encoding - {encoding_format}. Enter the valid encoding format")
+            raise Exception("Unknown Encoding - {}. Enter the valid encoding format".format(encoding_format))
     streams = discover_streams(config)
     if not streams:
         raise Exception("No streams found")

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -4,7 +4,7 @@ import singer
 
 from singer import metadata
 from singer import utils
-from singer_encoding import is_valid_encoding
+from singer_encoding.utils import is_valid_encoding
 from tap_sftp.discover import discover_streams
 from tap_sftp.sync import sync_stream
 from tap_sftp.stats import STATS

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -4,6 +4,7 @@ import singer
 
 from singer import metadata
 from singer import utils
+from singer_encoding import is_valid_encoding
 from tap_sftp.discover import discover_streams
 from tap_sftp.sync import sync_stream
 from tap_sftp.stats import STATS
@@ -11,9 +12,15 @@ from terminaltables import AsciiTable
 
 REQUIRED_CONFIG_KEYS = ["username", "port", "private_key_file", "host"]
 LOGGER = singer.get_logger()
+DEFAULT_ENCODING_FORMAT = "utf-8"
 
 def do_discover(config):
     LOGGER.info("Starting discover")
+    # validate the encoding format
+    encoding_format = config.get("encoding_format") or DEFAULT_ENCODING_FORMAT
+    if encoding_format != "utf-8":
+        if not is_valid_encoding(encoding_format):
+            raise Exception(f"Unknown Encoding - {encoding_format}. Enter the valid encoding format")
     streams = discover_streams(config)
     if not streams:
         raise Exception("No streams found")

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -18,9 +18,8 @@ def do_discover(config):
     LOGGER.info("Starting discover")
     # validate the encoding format
     encoding_format = config.get("encoding_format") or DEFAULT_ENCODING_FORMAT
-    if encoding_format != "utf-8":
-        if not is_valid_encoding(encoding_format):
-            raise Exception("Unknown Encoding - {}. Enter the valid encoding format".format(encoding_format))
+    if encoding_format != "utf-8" and not is_valid_encoding(encoding_format):
+        raise Exception("Unknown Encoding - {}. Enter the valid encoding format".format(encoding_format))
     streams = discover_streams(config, encoding_format)
     if not streams:
         raise Exception("No streams found")

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -18,7 +18,7 @@ def do_discover(config):
     LOGGER.info("Starting discover")
     # validate the encoding format
     encoding_format = config.get("encoding_format") or DEFAULT_ENCODING_FORMAT
-    if encoding_format != "utf-8" and not is_valid_encoding(encoding_format):
+    if not is_valid_encoding(encoding_format):
         raise Exception("Unknown Encoding - {}. Enter the valid encoding format".format(encoding_format))
     streams = discover_streams(config, encoding_format)
     if not streams:

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -4,7 +4,7 @@ import singer
 
 from singer import metadata
 from singer import utils
-from singer_encoding.utils import is_valid_encoding
+from singer_encodings.utils import is_valid_encoding
 from tap_sftp.discover import discover_streams
 from tap_sftp.sync import sync_stream
 from tap_sftp.stats import STATS

--- a/tap_sftp/__init__.py
+++ b/tap_sftp/__init__.py
@@ -21,7 +21,7 @@ def do_discover(config):
     if encoding_format != "utf-8":
         if not is_valid_encoding(encoding_format):
             raise Exception("Unknown Encoding - {}. Enter the valid encoding format".format(encoding_format))
-    streams = discover_streams(config)
+    streams = discover_streams(config, encoding_format)
     if not streams:
         raise Exception("No streams found")
     catalog = {"streams": streams}

--- a/tap_sftp/discover.py
+++ b/tap_sftp/discover.py
@@ -9,7 +9,7 @@ from tap_sftp import client
 
 LOGGER= singer.get_logger()
 
-def discover_streams(config):
+def discover_streams(config, encoding_format):
     streams = []
 
     conn = client.connection(config)
@@ -17,7 +17,7 @@ def discover_streams(config):
 
     tables = json.loads(config['tables'])
     for table_spec in tables:
-        schema, stream_md = get_schema(conn, table_spec)
+        schema, stream_md = get_schema(conn, table_spec, encoding_format)
 
         streams.append(
             {
@@ -38,9 +38,9 @@ def discover_streams(config):
                       interval=10,
                       jitter=None)
 # generate schema
-def get_schema(conn, table_spec):
+def get_schema(conn, table_spec, encoding_format):
     LOGGER.info('Sampling records to determine table JSON schema "%s".', table_spec['table_name'])
-    schema = json_schema.get_schema_for_table(conn, table_spec)
+    schema = json_schema.get_schema_for_table(conn, table_spec, encoding_format)
     stream_md = metadata.get_standard_metadata(schema,
                                                key_properties=table_spec.get('key_properties'),
                                                replication_method='INCREMENTAL')

--- a/tap_sftp/helper.py
+++ b/tap_sftp/helper.py
@@ -13,7 +13,8 @@ def write_message(message, ensure_ascii=True):
 
 
 def write_record(stream_name, record, stream_alias=None, time_extracted=None, ensure_ascii=True):
-    """Write a single record for the given stream.
+    """
+    Write a single record for the given stream.
     
     """
     write_message(RecordMessage(stream=(stream_alias or stream_name),

--- a/tap_sftp/helper.py
+++ b/tap_sftp/helper.py
@@ -1,0 +1,21 @@
+import simplejson as json
+import sys
+from singer import RecordMessage
+
+
+def format_message(message,ensure_ascii=True):
+    return json.dumps(message.asdict(), use_decimal=True, ensure_ascii=ensure_ascii)
+
+
+def write_message(message, ensure_ascii=True):
+    sys.stdout.write(format_message(message, ensure_ascii=ensure_ascii) + '\n')
+    sys.stdout.flush()
+
+
+def write_record(stream_name, record, stream_alias=None, time_extracted=None, ensure_ascii=True):
+    """Write a single record for the given stream.
+    
+    """
+    write_message(RecordMessage(stream=(stream_alias or stream_name),
+                                record=record,
+                                time_extracted=time_extracted), ensure_ascii=ensure_ascii)

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -6,6 +6,7 @@ import singer
 from singer import metadata, utils, Transformer
 from tap_sftp import client
 from tap_sftp import stats
+from tap_sftp.helper import write_record
 from singer_encodings import csv
 
 LOGGER = singer.get_logger()
@@ -86,7 +87,8 @@ def sync_file(conn, f, stream, table_spec, encoding_format):
 
                 to_write = transformer.transform(rec, stream.schema.to_dict(), metadata.to_map(stream.metadata))
 
-                singer.write_record(stream.tap_stream_id, to_write)
+                write_record(stream.tap_stream_id, to_write, ensure_ascii=False)
+                # singer.write_record(stream.tap_stream_id, to_write)
                 records_synced += 1
 
     stats.add_file_data(table_spec, f['filepath'], f['last_modified'], records_synced)

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -40,7 +40,7 @@ def sync_stream(config, state, stream):
         return records_streamed
 
     # Get the value of "encoding_format" from the configuration, defaulting to "DEFAULT_ENCODING_FORMAT"
-    encoding_format = config.get("encoding_format", DEFAULT_ENCODING_FORMAT)
+    encoding_format = config.get("encoding_format") or DEFAULT_ENCODING_FORMAT
 
     for f in files:
         records_streamed += sync_file(conn, f, stream, table_spec, encoding_format)

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -88,7 +88,6 @@ def sync_file(conn, f, stream, table_spec, encoding_format):
                 to_write = transformer.transform(rec, stream.schema.to_dict(), metadata.to_map(stream.metadata))
 
                 write_record(stream.tap_stream_id, to_write, ensure_ascii=False)
-                # singer.write_record(stream.tap_stream_id, to_write)
                 records_synced += 1
 
     stats.add_file_data(table_spec, f['filepath'], f['last_modified'], records_synced)

--- a/tap_sftp/sync.py
+++ b/tap_sftp/sync.py
@@ -42,18 +42,6 @@ def sync_stream(config, state, stream):
     # Get the value of "encoding_format" from the configuration, defaulting to "DEFAULT_ENCODING_FORMAT"
     encoding_format = config.get("encoding_format", DEFAULT_ENCODING_FORMAT)
 
-    try:
-        # Check if the encoding format is not "utf-8"
-        if encoding_format != "utf-8":
-            # Attempt to look up the codec for the specified encoding format
-            codecs.lookup(encoding_format)
-    except LookupError as err:
-        # If a LookupError occurs (invalid encoding format), log a warning
-        LOGGER.warning(f"{err}, setting the default encoding format - utf-8")
-        # Fall back to the default encoding format
-        encoding_format = DEFAULT_ENCODING_FORMAT
-
-
     for f in files:
         records_streamed += sync_file(conn, f, stream, table_spec, encoding_format)
         state = singer.write_bookmark(state, table_name, 'modified_since', f['last_modified'].isoformat())

--- a/tests/test_sftp_encoding.py
+++ b/tests/test_sftp_encoding.py
@@ -226,7 +226,6 @@ class TestSFTPEncoding(TestSFTPBase):
             headers = self.get_headers_for_table(tap_stream_id)
             
             for i in range(0, len(initial_records)):
-                initial_record = initial_records[i]
                 extracted_record = [extracted_messages[i]["data"][key] for key in headers]
-                self.assertEqual(initial_record, extracted_record)
+                self.assertEqual(initial_records[i], extracted_record)
 

--- a/tests/test_sftp_encoding.py
+++ b/tests/test_sftp_encoding.py
@@ -1,0 +1,182 @@
+from base import TestSFTPBase
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+import os
+import json
+import zipfile
+
+# Special characters for the encoding format
+# latin-1 - ç, è, ñ, ü, ©, ¿
+# cp424 (hebrew) - כּרששׁעפּצלם
+# cp866 (russioan) - Моя учительница
+
+
+RECORD_COUNT = {}
+class TestSFTPEncoding(TestSFTPBase):
+
+    def name(self):
+        return "tap_tester_sftp_encoding"
+
+    def get_files(self):
+        # TODO: write down the generator function for the special characters
+        return [
+            {
+                "headers": ['id', 'string_col', 'integer_col'],
+                "directory": "latin",
+                "files": ["table_1_latin.csv"],
+                "archive": 'table_1_latin.zip',
+                "num_rows": 50,
+                # "generator": self.generate_simple_csv_lines_typeA
+            },
+            {
+                "headers": ['id', 'string_col', 'datetime_col', 'number_col'],
+                "directory": "hebrew",
+                "files": ["table_2_hebrew.csv"],
+                "archive": 'table_2_hebrew.zip',
+                "num_rows": 50,
+                # "generator": self.generate_simple_csv_lines_typeB
+            },
+            {
+                "headers": ['id', 'string_col', 'integer_col'],
+                "directory": "russian",
+                "files": ["table_3_russian.csv"],
+                "archive": 'table_3_russian.zip',
+                "num_rows": 50,
+                # "generator": self.generate_simple_csv_lines_typeA
+            },
+        ]
+
+    def setUp(self):
+        if not all([x for x in [os.getenv('TAP_SFTP_USERNAME'),
+                                os.getenv('TAP_SFTP_PASSWORD'),
+                                os.getenv('TAP_SFTP_ROOT_DIR')]]):
+            #pylint: disable=line-too-long
+            raise Exception("set TAP_SFTP_USERNAME, TAP_SFTP_PASSWORD, TAP_SFTP_ROOT_DIR")
+
+        root_dir = os.getenv('TAP_SFTP_ROOT_DIR')
+
+        with self.get_test_connection() as client:
+            # drop all csv files in root dir
+            client.chdir(root_dir)
+            try:
+                TestSFTPEncoding.rm('tap_tester', client)
+            except FileNotFoundError:
+                pass
+            client.mkdir('tap_tester')
+            client.chdir('tap_tester')
+
+            # Add subdirectories
+            file_info = self.get_files()
+            for entry in file_info:
+                client.mkdir(entry['directory'])
+
+            # Add csv files
+            for file_group in file_info:
+                headers = file_group['headers']
+                directory = file_group['directory']
+                client.chdir(directory)
+                with client.open(file_group['archive'], 'w') as direct_file:
+                    with zipfile.ZipFile(direct_file, mode='w') as zip_file:
+                        lines = [headers] + file_group['generator'](file_group['num_rows'])
+                        total = ''
+                        for line in lines:
+                            total += ','.join((str(val) for val in line)) + '\n'
+                        for file_name in file_group['files']:
+                            zip_file.writestr(file_name, total)
+                client.chdir('..')
+
+    def expected_first_sync_row_counts(self):
+        return {
+            'table_1': 100,
+            'table_2': 150,
+            'table_3': 50
+        }
+
+    def get_properties(self):
+        props = self.get_common_properties()
+        props['tables'] = json.dumps([
+                {
+                    "table_name": "table_1",
+                    "search_prefix": os.getenv("TAP_SFTP_ROOT_DIR") + "/tap_tester",
+                    "delimiter": ",",
+                    "search_pattern": "table_1\.zip",
+                    "key_properties": ['id']
+                },
+                {
+                    "table_name": "table_2",
+                    "search_prefix": os.getenv("TAP_SFTP_ROOT_DIR") + "/tap_tester",
+                    "delimiter": ",",
+                    "search_pattern": "table_2\.zip",
+                    "key_properties": ['id'],
+                    "date_overrides": ["datetime_col"]
+                },
+                {
+                    "table_name": "table_3",
+                    "search_prefix": os.getenv("TAP_SFTP_ROOT_DIR") + "/tap_tester",
+                    "delimiter": ",",
+                    "search_pattern": "table_3\.zip",
+                    "key_properties": ['id'],
+                    "date_overrides": ["datetime_col"]
+                }
+            ])
+        return props
+
+    def test_run(self):
+
+        conn_id = connections.ensure_connection(self)
+
+        # run in discovery mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # verify check  exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        # verify the tap discovered the right streams
+        catalog = menagerie.get_catalogs(conn_id)
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], catalog))
+
+        # assert we find the correct streams
+        self.assertEqual(self.expected_check_streams(),
+                         found_catalog_names)
+
+        for tap_stream_id in self.expected_check_streams():
+            with self.subTest(stream=tap_stream_id):
+                found_stream = [c for c in catalog if c['tap_stream_id'] == tap_stream_id][0]
+
+                schema_and_metadata = menagerie.get_annotated_schema(conn_id, found_stream['stream_id'])
+                main_metadata = schema_and_metadata["metadata"]
+                stream_metadata = [mdata for mdata in main_metadata if mdata["breadcrumb"] == []][0]
+
+                # table-key-properties metadata
+                self.assertEqual(self.expected_pks()[tap_stream_id],
+                                 set(stream_metadata["metadata"]["table-key-properties"]))
+
+
+        for stream_catalog in catalog:
+            annotated_schema = menagerie.get_annotated_schema(conn_id, stream_catalog['stream_id'])
+            selected_metadata = connections.select_catalog_and_fields_via_metadata(conn_id,
+                                                                                   stream_catalog,
+                                                                                   annotated_schema,
+                                                                                   [])
+
+        # Run sync
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # verify the persisted schema was correct
+        messages_by_stream = runner.get_records_from_target_output()
+
+        # assert that each of the streams that we synced are the ones that we expect to see
+        record_count_by_stream = runner.examine_target_output_file(self,
+                                                                   conn_id,
+                                                                   self.expected_first_sync_streams(),
+                                                                   self.expected_pks())
+
+        # Verify that the full table was syncd
+        for tap_stream_id in self.expected_first_sync_streams():
+            self.assertEqual(self.expected_first_sync_row_counts()[tap_stream_id],
+                             record_count_by_stream[tap_stream_id])

--- a/tests/unittests/test_encoding_format.py
+++ b/tests/unittests/test_encoding_format.py
@@ -1,0 +1,69 @@
+import unittest
+import json
+import sys
+from unittest.mock import patch
+from io import StringIO
+from parameterized import parameterized
+from tap_sftp import do_discover
+
+
+class TestDoDiscover(unittest.TestCase):
+    """Unit tests for the do_discover function."""
+
+    def setUp(self):
+        # Create an instance of StringIO to capture stdout
+        self.mock_stdout = StringIO()
+
+    def tearDown(self):
+        # Reset sys.stdout to its original state
+        sys.stdout = sys.__stdout__
+
+    @parameterized.expand(
+        [
+            [
+                "utf-8",
+            ],
+            [
+                "latin_1",
+            ],
+        ]
+    )
+    @patch("tap_sftp.is_valid_encoding", return_value=True)
+    @patch("tap_sftp.discover_streams", return_value=["stream1", "stream2"])
+    def test_do_discover_valid_encoding(
+        self, encoding_format, mock_discover_streams, mock_is_valid_encoding
+    ):
+        """Test do_discover with a valid encoding format"""
+        config = {"encoding_format": encoding_format}
+        captured_output = sys.stdout
+
+        try:
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                do_discover(config)
+                output = mock_stdout.getvalue().strip()
+                expected_output = json.dumps(
+                    {"streams": ["stream1", "stream2"]}, indent=2
+                )
+                self.assertEqual(output, expected_output)
+        except Exception as e:
+            self.fail(f"Exception occurred: {str(e)}")
+
+        if encoding_format == "utf-8":
+            # Bypassing encoding check for `utf-8` as it is widely used
+            mock_is_valid_encoding.assert_not_called()
+        else:
+            mock_is_valid_encoding.assert_called_with("latin_1")
+        mock_discover_streams.assert_called_with(config)
+        self.assertEqual(captured_output, sys.stdout)  # Ensure sys.stdout is restored
+
+    @patch("tap_sftp.is_valid_encoding", return_value=False)
+    def test_do_discover_invalid_encoding(self, mock_is_valid_encoding):
+        """Test do_discover with an invalid encoding format."""
+        config = {"encoding_format": "invalid-encoding"}
+
+        with self.assertRaises(Exception) as context:
+            do_discover(config)
+
+        self.assertIn("Unknown Encoding -", str(context.exception))
+
+        mock_is_valid_encoding.assert_called_with("invalid-encoding")

--- a/tests/unittests/test_encoding_format.py
+++ b/tests/unittests/test_encoding_format.py
@@ -53,7 +53,7 @@ class TestDoDiscover(unittest.TestCase):
             mock_is_valid_encoding.assert_not_called()
         else:
             mock_is_valid_encoding.assert_called_with("latin_1")
-        mock_discover_streams.assert_called_with(config)
+        mock_discover_streams.assert_called_with(config, encoding_format)
         self.assertEqual(captured_output, sys.stdout)  # Ensure sys.stdout is restored
 
     @patch("tap_sftp.is_valid_encoding", return_value=False)

--- a/tests/unittests/test_encoding_format.py
+++ b/tests/unittests/test_encoding_format.py
@@ -37,16 +37,13 @@ class TestDoDiscover(unittest.TestCase):
         config = {"encoding_format": encoding_format}
         captured_output = sys.stdout
 
-        try:
-            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-                do_discover(config)
-                output = mock_stdout.getvalue().strip()
-                expected_output = json.dumps(
-                    {"streams": ["stream1", "stream2"]}, indent=2
-                )
-                self.assertEqual(output, expected_output)
-        except Exception as e:
-            self.fail(f"Exception occurred: {str(e)}")
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            do_discover(config)
+            output = mock_stdout.getvalue().strip()
+            expected_output = json.dumps(
+                {"streams": ["stream1", "stream2"]}, indent=2
+            )
+            self.assertEqual(output, expected_output)
 
         if encoding_format == "utf-8":
             # Bypassing encoding check for `utf-8` as it is widely used

--- a/tests/unittests/test_encoding_format.py
+++ b/tests/unittests/test_encoding_format.py
@@ -18,23 +18,35 @@ class TestDoDiscover(unittest.TestCase):
         # Reset sys.stdout to its original state
         sys.stdout = sys.__stdout__
 
-    @parameterized.expand(
-        [
-            [
-                "utf-8",
-            ],
-            [
-                "latin_1",
-            ],
-        ]
-    )
+
     @patch("tap_sftp.is_valid_encoding", return_value=True)
     @patch("tap_sftp.discover_streams", return_value=["stream1", "stream2"])
-    def test_do_discover_valid_encoding(
-        self, encoding_format, mock_discover_streams, mock_is_valid_encoding
+    def test_do_discover_valid_encoding_utf_8(
+        self, mock_discover_streams, mock_is_valid_encoding
     ):
         """Test do_discover with a valid encoding format"""
-        config = {"encoding_format": encoding_format}
+        config = {"encoding_format": "utf-8"}
+        captured_output = sys.stdout
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            do_discover(config)
+            output = mock_stdout.getvalue().strip()
+            expected_output = json.dumps(
+                {"streams": ["stream1", "stream2"]}, indent=2
+            )
+            self.assertEqual(output, expected_output)
+            mock_is_valid_encoding.assert_not_called()
+        mock_discover_streams.assert_called_with(config, "utf-8")
+        self.assertEqual(captured_output, sys.stdout)  # Ensure sys.stdout is restored
+
+
+    @patch("tap_sftp.is_valid_encoding", return_value=True)
+    @patch("tap_sftp.discover_streams", return_value=["stream1", "stream2"])
+    def test_do_discover_encoding_latin_1(
+        self, mock_discover_streams, mock_is_valid_encoding
+    ):
+        """Test do_discover with a valid encoding format"""
+        config = {"encoding_format": "latin_1"}
         captured_output = sys.stdout
 
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
@@ -45,14 +57,9 @@ class TestDoDiscover(unittest.TestCase):
             )
             self.assertEqual(output, expected_output)
 
-        if encoding_format == "utf-8":
-            # Bypassing encoding check for `utf-8` as it is widely used
-            mock_is_valid_encoding.assert_not_called()
-        else:
-            mock_is_valid_encoding.assert_called_with("latin_1")
-        mock_discover_streams.assert_called_with(config, encoding_format)
+        mock_is_valid_encoding.assert_called_with("latin_1")
         self.assertEqual(captured_output, sys.stdout)  # Ensure sys.stdout is restored
-
+    
     @patch("tap_sftp.is_valid_encoding", return_value=False)
     def test_do_discover_invalid_encoding(self, mock_is_valid_encoding):
         """Test do_discover with an invalid encoding format."""

--- a/tests/unittests/test_permission_error.py
+++ b/tests/unittests/test_permission_error.py
@@ -69,7 +69,8 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
+        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, \
+                                     {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(0, mocked_get_row_iterators.call_count)

--- a/tests/unittests/test_permission_error.py
+++ b/tests/unittests/test_permission_error.py
@@ -56,7 +56,11 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
+        rows_synced = sync.sync_file(conn, 
+                                     {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, 
+                                     None, 
+                                     {"key_properties": ["id"], "delimiter": ","}, 
+                                     encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(1, mocked_get_row_iterators.call_count)
@@ -69,8 +73,11 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, \
-                                     {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
+        rows_synced = sync.sync_file(conn, 
+                                     {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, 
+                                     None,
+                                     {"key_properties": ["id"], "delimiter": ","}, 
+                                     encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(0, mocked_get_row_iterators.call_count)
@@ -84,7 +91,11 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
+        rows_synced = sync.sync_file(conn, 
+                                     {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, 
+                                     None, 
+                                     {"key_properties": ["id"], "delimiter": ","}, 
+                                     encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(0, mocked_get_row_iterators.call_count)

--- a/tests/unittests/test_permission_error.py
+++ b/tests/unittests/test_permission_error.py
@@ -4,6 +4,7 @@ import tap_sftp.client as client
 import tap_sftp.sync as sync
 import paramiko
 
+DEFAULT_ENCODING_FORMAT = "utf-8"
 @mock.patch("tap_sftp.client.SFTPConnection.sftp")
 @mock.patch("tap_sftp.client.LOGGER.warn")
 class TestPermissionError(unittest.TestCase):
@@ -55,7 +56,7 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","})
+        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(1, mocked_get_row_iterators.call_count)
@@ -68,7 +69,7 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","})
+        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(0, mocked_get_row_iterators.call_count)
@@ -82,7 +83,7 @@ class TestPermissionError(unittest.TestCase):
 
         conn = client.SFTPConnection("10.0.0.1", "username", port="22")
 
-        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","})
+        rows_synced = sync.sync_file(conn, {"filepath": "/root_dir/file.csv.gz", "last_modified": "2020-01-01"}, None, {"key_properties": ["id"], "delimiter": ","}, encoding_format=DEFAULT_ENCODING_FORMAT)
         # check if "csv.get_row_iterators" is called if it is called then error has not occurred
         # if it is not called then error has occured and function returned from the except block
         self.assertEquals(0, mocked_get_row_iterators.call_count)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -147,14 +147,14 @@ class TimeoutBackoff(unittest.TestCase):
         """
         # mock 'get_schema_for_table' and raise 'socket.timeout' error
         mocked_get_schema_for_table.side_effect = socket.timeout
-
+        encoding_format = "utf-8"
         table_spec = {
             "table_name": "test"
         }
         before_time = datetime.now()
         with self.assertRaises(socket.timeout):
             # function call
-            discover.get_schema("test_conn", table_spec)
+            discover.get_schema("test_conn", table_spec, encoding_format)
         after_time = datetime.now()
 
         # verify that the tap backoff for 60 seconds
@@ -187,11 +187,12 @@ class TimeoutBackoff(unittest.TestCase):
         file = {
             "filepath": "/root/file.csv"
         }
+        encoding_format = "utf-8"
         # create connection
         conn = client.connection(config=config)
         with self.assertRaises(socket.timeout):
             # function call
-            sync.sync_file(conn=conn, f=file, stream="test_stream", table_spec=table_spec)
+            sync.sync_file(conn=conn, f=file, stream="test_stream", table_spec=table_spec, encoding_format=encoding_format)
 
         # verify that the tap backoff for 5 times
         self.assertEquals(mocked_get_row_iterators.call_count, 5)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -192,7 +192,10 @@ class TimeoutBackoff(unittest.TestCase):
         conn = client.connection(config=config)
         with self.assertRaises(socket.timeout):
             # function call
-            sync.sync_file(conn=conn, f=file, stream="test_stream", table_spec=table_spec, encoding_format=encoding_format)
+            sync.sync_file(conn=conn, 
+                           f=file, stream="test_stream", 
+                           table_spec=table_spec, 
+                           encoding_format=encoding_format)
 
         # verify that the tap backoff for 5 times
         self.assertEquals(mocked_get_row_iterators.call_count, 5)


### PR DESCRIPTION
# Description of change
Currently, Tap-sftp exclusively supports the utf-8 encoding format. In order to enhance its versatility and compatibility, we are planning to expand support to encompass all encoding formats specified by Python 3.9.

# Manual QA steps
 - Done the manual testing by passing different encoding formats.
 - Kept the encoding format blank in the configuration, to test it sets the default to _utf-8_
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
